### PR TITLE
Implement configurable welcome embed

### DIFF
--- a/cogs/welcome.py
+++ b/cogs/welcome.py
@@ -3,15 +3,17 @@ from discord.ext import commands
 from discord import app_commands
 from utils.configmanager import ConfigManager  # ✅ Centralized config
 
-# === Welcome Embed Constants ===
-EMBED_TITLE = "hi you,"
-EMBED_DESCRIPTION = ("think of this place like the moment\n"
-                     "right before the chorus hits\n"
-                     "still, honest,,\n"
-                     "a little sad\n"
-                     "but somehow sweeter for it")
-EMBED_IMAGE_URL = "https://i.pinimg.com/736x/c5/83/b6/c583b6f4ef35c73420ce15cbadb99250.jpg"
-EMBED_FOOTER = "⁺‧₊˚ ཐི⋆♱⋆ཋྀ ˚₊‧⁺"
+# === Default Welcome Embed Values ===
+DEFAULT_EMBED_TITLE = "hi you,"
+DEFAULT_EMBED_DESCRIPTION = ("think of this place like the moment\n"
+                            "right before the chorus hits\n"
+                            "still, honest,,\n"
+                            "a little sad\n"
+                            "but somehow sweeter for it")
+DEFAULT_EMBED_IMAGE_URL = (
+    "https://i.pinimg.com/736x/c5/83/b6/c583b6f4ef35c73420ce15cbadb99250.jpg"
+)
+DEFAULT_EMBED_FOOTER = "⁺‧₊˚ ཐི⋆♱⋆ཋྀ ˚₊‧⁺"
 EMBED_COLOR = 0xb5a12c
 
 
@@ -22,11 +24,22 @@ class Welcome(commands.Cog):
         self.config = ConfigManager()
 
     def build_welcome_embed(self):
-        embed = discord.Embed(title=EMBED_TITLE,
-                              description=EMBED_DESCRIPTION,
-                              color=EMBED_COLOR)
-        embed.set_image(url=EMBED_IMAGE_URL)
-        embed.set_footer(text=EMBED_FOOTER)
+        title = self.config.get("welcome_embed_title", DEFAULT_EMBED_TITLE)
+        description = self.config.get(
+            "welcome_embed_description", DEFAULT_EMBED_DESCRIPTION
+        )
+        image_url = self.config.get(
+            "welcome_embed_image_url", DEFAULT_EMBED_IMAGE_URL
+        )
+        footer = self.config.get("welcome_embed_footer", DEFAULT_EMBED_FOOTER)
+
+        embed = discord.Embed(
+            title=title,
+            description=description,
+            color=EMBED_COLOR,
+        )
+        embed.set_image(url=image_url)
+        embed.set_footer(text=footer)
         return embed
 
     # === SEND EMBED ===
@@ -74,6 +87,81 @@ class Welcome(commands.Cog):
             f"✅ {interaction.channel.mention} set as welcome channel.",
             ephemeral=True)
 
+    # === SET WELCOME EMBED FIELDS ===
+
+    @commands.command(name="setwelcomeembed")
+    @commands.has_permissions(administrator=True)
+    async def legacy_set_welcome_embed(self, ctx, *, args: str = ""):
+        """Update welcome embed configuration via a legacy command."""
+        updates = self.parse_embed_args(args)
+        for key, value in updates.items():
+            self.config.set(key, value)
+        if updates:
+            await ctx.send("✅ Updated welcome embed.")
+        else:
+            await ctx.send("❌ No valid fields provided.")
+
+    @app_commands.command(
+        name="setwelcomeembed",
+        description="Update the welcome embed settings.",
+    )
+    @app_commands.describe(
+        title="Embed title",
+        description="Embed description",
+        image="Image URL",
+        footer="Footer text",
+    )
+    @app_commands.checks.has_permissions(administrator=True)
+    async def slash_set_welcome_embed(
+        self,
+        interaction: discord.Interaction,
+        title: str | None = None,
+        description: str | None = None,
+        image: str | None = None,
+        footer: str | None = None,
+    ):
+        updates = {}
+        if title is not None:
+            updates["welcome_embed_title"] = title
+        if description is not None:
+            updates["welcome_embed_description"] = description
+        if image is not None:
+            updates["welcome_embed_image_url"] = image
+        if footer is not None:
+            updates["welcome_embed_footer"] = footer
+        for key, value in updates.items():
+            self.config.set(key, value)
+
+        if updates:
+            await interaction.response.send_message(
+                "✅ Updated welcome embed.", ephemeral=True
+            )
+        else:
+            await interaction.response.send_message(
+                "❌ No changes provided.", ephemeral=True
+            )
+
+    # === UTILITIES ===
+
+    def parse_embed_args(self, arg_str: str) -> dict:
+        """Parse key:value pairs from a command string."""
+        import shlex
+
+        tokens = shlex.split(arg_str)
+        updates = {}
+        for token in tokens:
+            if token.startswith("title:"):
+                updates["welcome_embed_title"] = token.split("title:", 1)[1]
+            elif token.startswith("description:"):
+                updates["welcome_embed_description"] = token.split(
+                    "description:", 1
+                )[1]
+            elif token.startswith("image:"):
+                updates["welcome_embed_image_url"] = token.split("image:", 1)[1]
+            elif token.startswith("footer:"):
+                updates["welcome_embed_footer"] = token.split("footer:", 1)[1]
+        return updates
+
 
 async def setup(bot):
     cog = Welcome(bot)
@@ -81,5 +169,6 @@ async def setup(bot):
     try:
         bot.tree.add_command(cog.slash_welcome)
         bot.tree.add_command(cog.slash_set_welcome)
+        bot.tree.add_command(cog.slash_set_welcome_embed)
     except discord.app_commands.errors.CommandAlreadyRegistered:
         pass

--- a/config.json
+++ b/config.json
@@ -4,5 +4,9 @@
     "auto_role_id": 1371369224475377684,
     "channel_litany": 1372328343306764319,
     "channel_narkissos": 1377395278931431526,
-    "channel_rewind": 1377398982225039502
+    "channel_rewind": 1377398982225039502,
+    "welcome_embed_title": "hi you,",
+    "welcome_embed_description": "think of this place like the moment\\nright before the chorus hits\\nstill, honest,,\\na little sad\\nbut somehow sweeter for it",
+    "welcome_embed_image_url": "https://i.pinimg.com/736x/c5/83/b6/c583b6f4ef35c73420ce15cbadb99250.jpg",
+    "welcome_embed_footer": "⁺‧₊˚ ཐི⋆♱⋆ཋྀ ˚₊‧⁺"
 }

--- a/utils/configmanager.py
+++ b/utils/configmanager.py
@@ -23,8 +23,8 @@ class ConfigManager:
         with open(self.path, "w") as f:
             json.dump(self.config, f, indent=4)
 
-    def get(self, key):
-        return self.config.get(key)
+    def get(self, key, default=None):
+        return self.config.get(key, default)
 
     def set(self, key, value):
         self.config[key] = value


### PR DESCRIPTION
## Summary
- add default embed config fields to `config.json`
- allow retrieving config values with defaults
- make the welcome embed read from configuration
- provide slash and legacy commands to update welcome embed settings

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848afeddb5883338ac67db8eab4ca3f