### PR TITLE
Restrict nuke to manage_channels

### DIFF
--- a/cogs/nuke.py
+++ b/cogs/nuke.py
@@ -85,6 +85,7 @@ class Nuke(commands.Cog):
         self.bot = bot
 
     @commands.command(name="nuke")
+    @commands.has_permissions(manage_channels=True)
     async def legacy_nuke(self, ctx):
         view = NukeView(author=ctx.author, channel=ctx.channel)
         embed = discord.Embed(
@@ -95,6 +96,7 @@ class Nuke(commands.Cog):
         await ctx.send(embed=embed, view=view)
 
     @app_commands.command(name="nuke", description="Nuke this channel (deletes and recreates it).")
+    @app_commands.checks.has_permissions(manage_channels=True)
     async def slash_nuke(self, interaction: discord.Interaction):
         view = NukeView(author=interaction.user, channel=interaction.channel)
         embed = discord.Embed(


### PR DESCRIPTION
## Summary
- limit `/nuke` and `nuke` to members with `manage_channels` permissions

## Testing
- `python -m py_compile cogs/nuke.py`

------
https://chatgpt.com/codex/tasks/task_e_686040f716c08333b2bacfdc2474fba9